### PR TITLE
proposal for run_basic_service.py

### DIFF
--- a/Services/gRPC/Basic_Template/run_basic_service.py
+++ b/Services/gRPC/Basic_Template/run_basic_service.py
@@ -4,71 +4,60 @@ import time
 import os
 import sys
 import logging
-import threading
-
 from service import registry
+import argparse
 
 logging.basicConfig(level=10, format="%(asctime)s - [%(levelname)8s] - %(name)s - %(message)s")
 log = logging.getLogger("run_basic_service")
 
 
 def main():
-
+    parser = argparse.ArgumentParser(description='Run services')
+    parser.add_argument('--no-daemon', action='store_false', dest="is_run_daemon", help='do not start the daemon')
+    args = parser.parse_args()
     root_path = pathlib.Path(__file__).absolute().parent
 
     # All services modules go here
     service_modules = ["service.basic_service_one"]
 
-    # Removing all previous snetd .db file
-    os.system("rm snetd*.db")
-
     # Call for all the services listed in service_modules
-    start_all_services(root_path, service_modules)
+    all_p = start_all_services(root_path, service_modules, args.is_run_daemon)
 
-    # Infinite loop to serve the services
-    while True:
-        try:
-            time.sleep(1)
-        except Exception as e:
-            log.error(e)
-            exit(0)
+    # Wait for all subprocesses
+    try:
+        for p in all_p:
+            p.wait()
+    except Exception as e:
+        log.error(e)
+        raise
 
 
-def start_all_services(cwd, service_modules):
+def start_all_services(cwd, service_modules, is_run_daemon):
     """
     Loop through all service_modules and start them.
     For each one, an instance of Daemon "snetd" is created.
     snetd will start with configs from "snetd.config.json"
     """
-    try:
-        for i, service_module in enumerate(service_modules):
-            service_name = service_module.split(".")[-1]
-            log.info("Launching {} on port {}".format(str(registry[service_name]), service_module))
+    all_p = []
+    for i, service_module in enumerate(service_modules):
+        service_name = service_module.split(".")[-1]
+        log.info("Launching {} on port {}".format(str(registry[service_name]), service_module))
+        all_p += start_service(cwd, service_module, is_run_daemon)
+    return all_p
 
-            process_th = threading.Thread(target=start_service, args=(cwd, service_module))
-
-            # Bind the thread with the main() to abort it when main() exits.
-            process_th.daemon = True
-            process_th.start()
-
-    except Exception as e:
-        log.error(e)
-        return False
-    return True
-
-
-def start_service(cwd, service_module):
+def start_service(cwd, service_module, is_run_daemon):
     """
     Starts SNET Daemon ("snetd") and the python module of the service
     at the passed gRPC port.
     """
-    start_snetd(str(cwd))
-
+    all_p = []
+    if (is_run_daemon):
+        all_p.append(start_snetd(str(cwd)))
     service_name = service_module.split(".")[-1]
     grpc_port = registry[service_name]["grpc"]
-    subprocess.Popen(
-        [sys.executable, "-m", service_module, "--grpc-port", str(grpc_port)],
-        cwd=str(cwd))
+    p = subprocess.Popen([sys.executable, "-m", service_module, "--grpc-port", str(grpc_port)], cwd=str(cwd))
+    all_p.append(p)
+    return all_p
 
 
 def start_snetd(cwd):
@@ -76,8 +65,7 @@ def start_snetd(cwd):
     Starts the Daemon "snetd":
     """
     cmd = ["snetd", "serve"]
-    subprocess.Popen(cmd, cwd=str(cwd))
-    return True
+    return subprocess.Popen(cmd, cwd=str(cwd))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
New version for Services/gRPC/Basic_Template/run_basic_service.py

- Add option to run without daemon. "run_basic_service.py --no-daemon" will run service without snetd. "run_basic_service.py" will fail completely if it will not be able to run snetd.
- remove pattern of running popen inside threads.
- Wait for subprocess to finish, not to sleep (which is not the same)
- remove error hiding pattern
  