### PR TITLE
[s2vt] Using string for backwards compatibility.

### DIFF
--- a/services/s2vt-video-captioning/service/service_spec/video_cap.proto
+++ b/services/s2vt-video-captioning/service/service_spec/video_cap.proto
@@ -2,8 +2,8 @@ syntax = "proto3";
 
 message Input {
     string url = 1;
-    float start_time_sec = 2;
-    float stop_time_sec = 3;
+    string start_time_sec = 2;
+    string stop_time_sec = 3;
 }
 
 message Output {

--- a/services/s2vt-video-captioning/service/video_captioner.py
+++ b/services/s2vt-video-captioning/service/video_captioner.py
@@ -20,8 +20,8 @@ class VideoCaptioner:
         self.video_path = ""
         self.uid = uid
         self.video_folder = "./service/utils/videos/{}".format(self.uid)
-        self.start_time = start_time
-        self.stop_time = stop_time
+        self.start_time = float(start_time) if start_time else 0
+        self.stop_time = float(stop_time) if stop_time else 0
         self.pace = pace
         self.batch_size = batch_size
         self.error = ""

--- a/services/s2vt-video-captioning/test_video_cap_service.py
+++ b/services/s2vt-video-captioning/test_video_cap_service.py
@@ -28,10 +28,10 @@ if __name__ == "__main__":
         grpc_method = raw_input("Method (video_cap): ") if not test_flag else ""
         if grpc_method == "video_cap" or grpc_method == "":
             url = raw_input("Url: ") if not test_flag else TEST_URL
-            start_time_sec = raw_input("StartTime(s): ") if not test_flag else 0
-            stop_time_sec = raw_input("StopTime (s): ") if not test_flag else 0
+            start_time_sec = raw_input("StartTime(s): ") if not test_flag else "0"
+            stop_time_sec = raw_input("StopTime (s): ") if not test_flag else "0"
             stub = grpc_bt_grpc.VideoCaptioningStub(channel)
-            request = grpc_bt_pb2.Input(url=url, start_time_sec=float(start_time_sec), stop_time_sec=float(stop_time_sec))
+            request = grpc_bt_pb2.Input(url=url, start_time_sec=start_time_sec, stop_time_sec=stop_time_sec)
             response = stub.video_cap(request)
             print(response.value)
 


### PR DESCRIPTION
-   Please make sure the below checklist is followed for Pull Requests.

-   [x] CircleCI tests are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md](https://dev.singularitynet.io/docs/contribute/contribution-guidelines/) document are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip CircleCI tests
-->

Using string in `.proto` to keep compatibility with dApp and mainnet Registry.