### PR TITLE
[sound-spleeter] Setting 'max_message_size_in_mb' option.

### DIFF
--- a/services/sound-spleeter/run_sound_spleeter_service.py
+++ b/services/sound-spleeter/run_sound_spleeter_service.py
@@ -79,6 +79,7 @@ def start_service(cwd, service_module, run_daemon, run_ssl):
                 snetd_configs["ethereum_json_rpc_endpoint"] = "https://{}.infura.io/{}".format(_network, infura_key)
             snetd_configs["metering_end_point"] = "https://{}-marketplace.singularitynet.io".format(_network)
             snetd_configs["pvt_key_for_metering"] = os.environ.get("PVT_KEY_FOR_METERING", "")
+            snetd_configs["max_message_size_in_mb"] = os.environ.get("MAX_MESSAGE_SIZE", 25)
         with open(conf, "w") as f:
             json.dump(snetd_configs, f, sort_keys=True, indent=4)
     

--- a/services/sound-spleeter/service/sound_spleeter.py
+++ b/services/sound-spleeter/service/sound_spleeter.py
@@ -30,8 +30,8 @@ def spleeter(response, audio_url=None, audio=None):
                 size = r.headers.get('content-length', 0)
                 size = int(size) / float(1 << 20)
                 log.info("File size: {:.2f} Mb".format(size))
-                if size > 5:
-                    response["vocals"] = b"Input audio file is too large! (max 5Mb)"
+                if size > 10:
+                    response["vocals"] = b"Input audio file is too large! (max 10Mb)"
                     response["accomp"] = b"Fail"
                     return
                 r = requests.get(audio_url, headers=header, allow_redirects=True)

--- a/services/sound-spleeter/service/sound_spleeter_service.py
+++ b/services/sound-spleeter/service/sound_spleeter_service.py
@@ -60,7 +60,9 @@ def generate_uid():
 # Add all your classes to the server here.
 # (from generated .py files by protobuf compiler)
 def serve(max_workers=10, port=7777):
-    server = grpc.server(futures.ThreadPoolExecutor(max_workers=max_workers))
+    server = grpc.server(futures.ThreadPoolExecutor(max_workers=max_workers), options=[
+        ('grpc.max_send_message_length', 25 * 1024 * 1024),
+        ('grpc.max_receive_message_length', 25 * 1024 * 1024)])
     grpc_bt_grpc.add_SoundSpleeterServicer_to_server(SoundSpleeterServicer(), server)
     server.add_insecure_port("[::]:{}".format(port))
     return server


### PR DESCRIPTION
-   Please make sure the below checklist is followed for Pull Requests.

-   [x] CircleCI tests are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md](https://dev.singularitynet.io/docs/contribute/contribution-guidelines/) document are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip CircleCI tests
-->

Increasing the `"max_message_size_in_mb"` in Daemon's config to make the service able to receive and send messages (audio files content) with total size of 25Mb (default was `4Mb`).